### PR TITLE
pycryptodome should be the only requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,1 @@
-crypto
-pycrypto
 pycryptodome


### PR DESCRIPTION
It is advised to not require `crypto` along with `pycryptodome` since they may conflict with one another. I think I did this originally, but I am resolving it now. 

`pycryptodome` is our only requirement at the moment, so I removed the other requirements. 