### PR TITLE
Fixing bug with sending objects over the network

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,12 +3,6 @@
 .DS_Store
 venv
 __pycache__
-<<<<<<< HEAD
 *.key
 *.pem
 .pytest_cache/
-=======
-rootCA.key
-rootCA.pem
-.idea/
->>>>>>> 916b05d916ef8d3338642fc811c4187715301cb1

--- a/src/node.py
+++ b/src/node.py
@@ -28,6 +28,7 @@ class Node(ABC):
         if not bind:
             assert hostname != None, "Hostname must be specified when not binding"
             self.hostname = hostname
+            self.address = (socket.gethostbyname(self.hostname), port)
         else:
             self.hostname = hostname or socket.getfqdn(socket.gethostname())
             self._init_net()

--- a/src/validator.py
+++ b/src/validator.py
@@ -52,7 +52,7 @@ class Validator(Node):
 
             :param bytearray data: The certificate file
         '''
-        newfilename = lambda namelength: ''.join(
+        def newfilename(namelength): return ''.join(
             choice(ascii_uppercase + ascii_lowercase + digits) for _ in range(namelength))
 
         # Create a random filename of length 15
@@ -92,6 +92,8 @@ class Validator(Node):
             address = v.address
             if isinstance(msg, str):
                 msg = msg.encode()  # encode the msg to binary
+            elif isinstance(msg, Transaction) or isinstance(msg, Block):
+                msg = pickle.dumps(msg)
             print("Attempting to send to %s:%s" % v.address)
             secure_conn = self.context.wrap_socket(
                 socket.socket(socket.AF_INET, socket.SOCK_STREAM), server_hostname=v.hostname)
@@ -108,7 +110,8 @@ class Validator(Node):
             finally:
                 secure_conn.close()
         else:
-            raise Exception("The net must be initialized and listening for connections")
+            raise Exception(
+                "The net must be initialized and listening for connections")
 
     def broadcast(self, tx):
         '''
@@ -167,7 +170,7 @@ class Validator(Node):
                     DATA = DATA[5:]  # Remove flag
                     self.save_new_certfile(data=DATA)
                     return
-                
+
                 # Deserialize the entire object when data reception has ended
                 decoded_message = pickle.loads(DATA)
                 print("Received data from %s:%d: %s" %
@@ -224,7 +227,7 @@ class Validator(Node):
             nonce=0,
             status="Proposed"
         )
-    
+
     def send_certificate(self, addr, port):
         '''
             Sends the certificate to addr:port through 
@@ -256,15 +259,16 @@ class Validator(Node):
             if tx not in self.mempool:
                 return False
         return True
-        
+
+
 if __name__ == "__main__":
     port = int(input("Enter a port number: "))
     val = Validator(hostname="localhost", port=port)
-    val2 = Validator(hostname="localhost", port=port+1)
+    marshal = Validator(hostname="home.marshalh.com", port=8080, bind=False)
 
     try:
         while True:
-            val.receive('insecure')
-            val2.send_certificate(addr=val.address[0], port=val.address[1])
+            tx = Transaction(inputs=0)
+            val.message(marshal, tx)
     except KeyboardInterrupt:
         val.close()

--- a/src/validator.py
+++ b/src/validator.py
@@ -270,5 +270,6 @@ if __name__ == "__main__":
         while True:
             tx = Transaction(inputs=0)
             val.message(marshal, tx)
+            time.sleep(1)
     except KeyboardInterrupt:
         val.close()

--- a/src/validator.py
+++ b/src/validator.py
@@ -192,11 +192,11 @@ class Validator(Node):
                         start_time = int(time.time())
                         last = None
                         self.create_block(self.mempool[:10], last)
-                elif type(data) == Block:
+                elif type(decoded_message) == Block:
                     print("Call verification/consensus function to vote on Block")
                 else:
                     print("Data received was not of type Transaction or Block, but of type %s: \n%s\n" % (
-                        type(data), data))
+                        type(decoded_message), decoded_message))
         except socket.timeout:
             pass
 


### PR DESCRIPTION
This PR fixes an issue with `type` mismatching when sending serialized objects over the network. 