### PR TITLE
Refactoring Validator & Client CA (Public Key) functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 .vscode
 *.pyc
 .DS_Store
-venv
+.venv
 __pycache__
 *.key
 *.pem

--- a/src/block.py
+++ b/src/block.py
@@ -13,7 +13,7 @@ class Block:
 
         # A version number to track software protocol upgrades
         self.version = version
-        self.id = id # Block index or block height
+        self.id = id  # Block index or block height
         # Transaction pool created by validator calling add_transaction() method
         self.transactions = transactions
         # Transaction pool with hashed transactions
@@ -33,9 +33,9 @@ class Block:
         self.status = status
         # Total number of transaction included in this block => This will be used to verify the transaction from merkel root
         self.t_counter = len(self.transactions)
-        self.timestamp = int(time.time()) # Creation time of this block
-        self.hash = self.compute_hash() # The hash of the block header
-        
+        self.timestamp = int(time.time())  # Creation time of this block
+        self.hash = self.compute_hash()  # The hash of the block header
+
     def merkle_root_hash(self, transactions):
         '''
             param list: transactions: list of raw transaction
@@ -93,8 +93,9 @@ class Block:
         return self.compute_hash() == other.compute_hash()
 
     def __str__(self):
-        s = "<Block>\n"
+        classname = self.__class__.__name__
+        s = "<%s>\n" % classname
         for attr, value in self.__dict__.items():
             s += "\t --%s: %s\n" % (attr, value or "None")
-        s += "</Block>"
+        s += "</%s>" % classname
         return s

--- a/src/blockchain.py
+++ b/src/blockchain.py
@@ -1,5 +1,6 @@
 from block import Block
 from transaction import Transaction
+
 import json
 import time
 
@@ -30,7 +31,7 @@ class Blockchain:
     def __init__(self):
         self.unconfirmed_transactions = []
         self.chain = []
-        #self.create_genesis_block()
+        # self.create_genesis_block()
 
     def create_genesis_block(self):
         inputs_1 = {"REGISTER": {"name": "Noah Coomer",
@@ -66,7 +67,7 @@ class Blockchain:
     # last_block() returns the last block of the chain
     @property
     def last_block(self):
-        return self.chain[-1]
+        return self.chain[-1] if len(self.chain) > 0 else None
 
     # Generate a concensus_hash number based on the concensus algorithms
     # This consensus algorithm does not use proof of work

--- a/src/client.py
+++ b/src/client.py
@@ -1,7 +1,7 @@
 from node import Node
+from block import Block
 from blockchain import Blockchain
 from transaction import Transaction
-from block import Block
 import validator
 
 from Crypto import Random
@@ -20,6 +20,7 @@ import pickle
 
 BUFF_SIZE = 2048
 
+
 class Client(Node):
     def __init__(self, hostname=None, addr="0.0.0.0", port=4848, bind=True, capath="~/.BlockchainPKI/validators/",
                  certfile="~/.BlockchainPKI/rootCA.pem", keyfile="~/.BlockchainPKI/rootCA.key"):
@@ -29,22 +30,17 @@ class Client(Node):
             :param int port: The port for serving inbound connections
             :param str capath:
         '''
-        super().__init__(hostname=hostname, addr=addr, port=port, bind=bind, capath=capath)
-        #self.name = hostname or socket.getfqdn(socket.gethostname())
-        #self.address = addr, port
-        #self.validators_capath = capath
+        super().__init__(hostname=hostname, addr=addr, port=port,
+                         bind=bind, capath=capath, certfile=certfile, keyfile=keyfile)
+
         self.blockchain = Blockchain()
-        self.connections = []
-        #self._init_net()
-        self.certfile = certfile.replace('~', os.environ['HOME'])
-        self.keyfile = keyfile.replace('~', os.environ['HOME'])
-        self.receive_context = ssl.create_default_context(
-            ssl.Purpose.CLIENT_AUTH)
-        self.receive_context.load_cert_chain(self.certfile, self.keyfile)  
+        self.connections = list()
 
     def message(self, t):
         '''
             Send a Transaction to the validator network
+
+            :param Transaction t: The transaction to send
         '''
         pass
 
@@ -69,11 +65,8 @@ class Client(Node):
                     if type(decoded_message) == Block:
                         if decoded_message not in self.blockchain.chain:
                             self.blockchain.chain.append(decoded_message)
-
             except socket.timeout:
                 pass
-
-
 
     def create_connections(self):
         '''
@@ -117,7 +110,8 @@ class Client(Node):
                 except socket.error as e:
                     print(e)
         else:
-            raise Exception("The validator must be initialized and listening for connections")
+            raise Exception(
+                "The validator must be initialized and listening for connections")
 
     def broadcast_transaction(self, tx):
         '''
@@ -125,7 +119,7 @@ class Client(Node):
         '''
         for i in self.connections:
             self.send_transaction(i, tx)
-            
+
     def update_blockchain(self):
         '''
             Update blockchain to be current
@@ -135,11 +129,11 @@ class Client(Node):
         chain = None
         if os.path.exists(block_path):
             print("Loading local blockchain files...")
-            ### Need to implement this
+            # Need to implement this
         else:
             # Else make the block path and initialize a chain
             # Uncomment next line when serialization is finished
-            #os.path.mkdir(block_path) 
+            # os.path.mkdir(block_path)
             chain = Blockchain()
         # Broadcast the last block of our current chain to let the network know we need blocks after this point
         # Uncomment next line before going live
@@ -171,12 +165,14 @@ class Client(Node):
             # public key verification
             gen = self.verify_public_key(open(generator_public_key, 'r'))
             if not gen:
-                print("The generator public key is incorrectly formatted. Please try again.")
+                print(
+                    "The generator public key is incorrectly formatted. Please try again.")
                 return -1
 
             pub = self.verify_public_key(open(public_key, 'r'))
             if not pub:
-                print("The register public key is incorrectly formatted. Please try again.")
+                print(
+                    "The register public key is incorrectly formatted. Please try again.")
                 return -1
 
         inputs = {"REGISTER": {name: pub}}
@@ -211,10 +207,11 @@ class Client(Node):
         outputs = json.dumps(outputs)
 
         # send the transaction and return it for std.out
-        tx = Transaction(transaction_type="Standard", tx_generator_address=gen, inputs=inputs, outputs=outputs)
+        tx = Transaction(transaction_type="Standard",
+                         tx_generator_address=gen, inputs=inputs, outputs=outputs)
         # Create an entry point to the validator network that the client can connect to
 
-        #self.broadcast_transaction(tx)
+        # self.broadcast_transaction(tx)
         return tx
 
     def pki_query(self, generator_public_key, name):
@@ -256,9 +253,9 @@ class Client(Node):
         outputs = json.dumps(outputs)
 
         tx = Transaction(transaction_type="Standard", tx_generator_address=gen,
-                                    inputs=inputs, outputs=outputs)
+                         inputs=inputs, outputs=outputs)
 
-        #self.broadcast_transaction(tx)
+        # self.broadcast_transaction(tx)
         return tx
 
     def pki_validate(self, generator_public_key, name, public_key):
@@ -276,12 +273,14 @@ class Client(Node):
         else:
             gen = self.verify_public_key(open(generator_public_key, 'r'))
             if not gen:
-                print("The generator public key is incorrectly formatted. Please try again.")
+                print(
+                    "The generator public key is incorrectly formatted. Please try again.")
                 return - 1
 
             pub = self.verify_public_key(open(public_key, 'r'))
             if not pub:
-                print("The register public key is incorrectly formatted. Please try again.")
+                print(
+                    "The register public key is incorrectly formatted. Please try again.")
                 return -1
 
         if len(name) < 1 or len(name) > 255:
@@ -310,7 +309,8 @@ class Client(Node):
 
         outputs = dict()
         if flag == True:
-            outputs = {"VALIDATE": {"success": True, "name": name, "public_key": pub}}
+            outputs = {"VALIDATE": {"success": True,
+                                    "name": name, "public_key": pub}}
         else:
             outputs = {"VALIDATE": {"success": False,
                                     "message": "Cannot validate name and public key"}}
@@ -393,12 +393,14 @@ class Client(Node):
             # input verification
             gen = self.verify_public_key(open(generator_public_key, 'r'))
             if not gen:
-                print("The generator public key is incorrectly formatted. Please try again.")
+                print(
+                    "The generator public key is incorrectly formatted. Please try again.")
                 return -1
 
             pub = self.verify_public_key(open(public_key, 'r'))
             if not pub:
-                print("The entered public key is incorrectly formatted. Please try again.")
+                print(
+                    "The entered public key is incorrectly formatted. Please try again.")
                 return -1
 
         inputs = {"REVOKE": {"public_key": pub}}
@@ -430,7 +432,7 @@ class Client(Node):
         inputs = json.dumps(inputs)
         outputs = json.dumps(outputs)
         tx = Transaction(transaction_type="Standard", tx_generator_address=gen,
-                                     inputs=inputs, outputs=outputs)
+                         inputs=inputs, outputs=outputs)
         return tx
 
     def print_chain(self):
@@ -477,7 +479,8 @@ class Client(Node):
                 reg_pub_key_path = input(
                     "Enter the path of the public key you would like to register: ")
                 #reg_pub_key = open(reg_pub_key_path, 'r')
-                tx = self.pki_register(client_pub_key_path, name, reg_pub_key_path)
+                tx = self.pki_register(
+                    client_pub_key_path, name, reg_pub_key_path)
                 self.broadcast_transaction(tx)
                 print(tx)
             elif command[0] == 'query':
@@ -496,7 +499,8 @@ class Client(Node):
                 val_pub_key_path = input(
                     "Enter the path of the public key you would like to validate: ")
                 #val_pub_key = open(val_pub_key_path, 'r')
-                tx = self.pki_validate(client_pub_key_path, name, val_pub_key_path)
+                tx = self.pki_validate(
+                    client_pub_key_path, name, val_pub_key_path)
                 self.broadcast_transaction(tx)
                 print(tx)
             elif command[0] == 'update':
@@ -567,7 +571,8 @@ class Client(Node):
                 print("Created %s" % key_path)
 
         # write out the private key
-        priv_key_name = input("Enter a filename (no extension) for your private key: ")
+        priv_key_name = input(
+            "Enter a filename (no extension) for your private key: ")
         file_out = open(os.path.join(key_path, priv_key_name + ".pem"), 'wb')
         file_out.write(private_key.export_key('PEM'))
         print(
@@ -575,7 +580,8 @@ class Client(Node):
         file_out.close()
 
         # write out the public key
-        pub_key_name = input("Enter a filename (no extension) for your public key: ")
+        pub_key_name = input(
+            "Enter a filename (no extension) for your public key: ")
         file_out = open(os.path.join(key_path, pub_key_name + ".pem"), 'wb')
         file_out.write(private_key.publickey().export_key('PEM'))
         print(
@@ -598,6 +604,7 @@ class Client(Node):
             return key
         except ValueError:
             return None
+
 
 if __name__ == '__main__':
     cli = Client()

--- a/src/node.py
+++ b/src/node.py
@@ -12,7 +12,8 @@ class Node(ABC):
         Base class for a generic node
     '''
 
-    def __init__(self, hostname=None, addr="0.0.0.0", port=4848, bind=True, capath="~/.BlockchainPKI/validators/"):
+    def __init__(self, hostname=None, addr="0.0.0.0", port=4848, bind=True, capath="~/.BlockchainPKI/validators/",
+                 certfile="~/.BlockchainPKI/rootCA.pem", keyfile="~/.BlockchainPKI/rootCA.key"):
         '''
             Initialize the Node object
 
@@ -32,6 +33,12 @@ class Node(ABC):
         else:
             self.hostname = hostname or socket.getfqdn(socket.gethostname())
             self._init_net()
+
+            self.certfile = certfile.replace('~', os.environ['HOME'])
+            self.keyfile = keyfile.replace('~', os.environ['HOME'])
+            self.receive_context = ssl.create_default_context(
+                ssl.Purpose.CLIENT_AUTH)
+            self.receive_context.load_cert_chain(self.certfile, self.keyfile)
 
     def _init_net(self):
         '''
@@ -74,6 +81,8 @@ class Node(ABC):
     def load_other_ca(self, capath=None):
         '''
             Loads a list of certificates from capath into the SSLContext
+
+            :param str capath: The path to load from. Can absolute or relative to $HOME.
         '''
         capath = capath or self.capath
         capath = capath.replace('~', os.environ['HOME'])
@@ -92,6 +101,27 @@ class Node(ABC):
             for path in cafiles:
                 abspath = os.path.join(capath, path)
                 self.context.load_verify_locations(abspath)
+
+    def send_certificate(self, addr, port):
+        '''
+            Sends the certificate to addr:port through 
+            standard, unencrypted TCP
+
+            :param str addr: the ipv4 address to send to
+            :param int port: the port number to send to
+        '''
+        certfile = open(self.certfile, 'rb').read()
+        print("Read certfile. Attempting to send to %s:%d" % (addr, port))
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            try:
+                s.connect((addr, port))
+                # Alert receiver that you want to send a certificate
+                s.send(b'/cert')
+                s.sendall(certfile)  # Send the certificate
+            except OSError as e:
+                print(e)
+            except socket.timeout as e:
+                print(e)
 
     def close(self):
         if self.net != None:

--- a/src/transaction.py
+++ b/src/transaction.py
@@ -2,6 +2,7 @@ import time
 import hashlib
 import pickle
 
+
 class Transaction:
     def __init__(self, version=0.1, transaction_type=None, tx_generator_address=None,
                  inputs=None, outputs=None, lock_time=None):
@@ -39,8 +40,9 @@ class Transaction:
         return self.compute_hash() == other.compute_hash()
 
     def __str__(self):
-        s = "<Transaction>\n"
+        classname = self.__class__.__name__
+        s = "<%s>\n" % classname
         for attr, value in self.__dict__.items():
             s += "\t --%s: %s\n" % (attr, value or "None")
-        s += "</Transaction>"
+        s += "</%s>" % classname
         return s

--- a/src/validator.py
+++ b/src/validator.py
@@ -29,26 +29,20 @@ class Validator(Node):
             :param str certfile: The path to the CA
             :param str keyfile: The path to the private key
         '''
-        super().__init__(hostname=hostname, addr=addr, port=port, bind=bind, capath=capath)
+        super().__init__(hostname=hostname, addr=addr, port=port,
+                         bind=bind, capath=capath, certfile=certfile, keyfile=keyfile)
 
         # Buffer to store incoming transactions
         self.mempool = list()
-        self.blockchain = Blockchain() #list()
+        self.blockchain = Blockchain()  # list()
         self.block = Block()
+
         # Buffer to store connection objects
         self.connections = list()
-        # Buffer to store client connection objects
         self.client_connections = list()
 
-        self.certfile = certfile.replace('~', os.environ['HOME'])
-        self.keyfile = keyfile.replace('~', os.environ['HOME'])
-
-        self.receive_context = ssl.create_default_context(
-            ssl.Purpose.CLIENT_AUTH)
-        self.receive_context.load_cert_chain(self.certfile, self.keyfile)
-        self.first = 0 # First index of the new sent tx mempool
+        self.first = 0  # First index of the new sent tx mempool
         self.last = 0   # Last index of the new sent tx mempool
-        
 
     def create_connections(self):
         '''
@@ -101,8 +95,10 @@ class Validator(Node):
     def message(self, v, msg):
         '''
             Send a message to another Validator
+
             :param Validator v: receiver of the message
             :param msg: the message to send
+
             v's net should be initialized and listening for incoming connections,
             probably bound to listen for all connections (addr="0.0.0.0").
             msg must be an instance of str or bytes.
@@ -114,6 +110,10 @@ class Validator(Node):
                 msg = msg.encode()  # encode the msg to binary
             elif isinstance(msg, Transaction) or isinstance(msg, Block):
                 msg = pickle.dumps(msg)
+            else:
+                raise TypeError(
+                    "Only Transaction, Block, or str types are allowed (not %s)" % type(msg))
+
             print("Attempting to send to %s:%s" % v.address)
             secure_conn = self.context.wrap_socket(
                 socket.socket(socket.AF_INET, socket.SOCK_STREAM), server_hostname=v.hostname)
@@ -189,8 +189,6 @@ class Validator(Node):
 
                 # Deserialize the entire object when data reception has ended
                 decoded_message = pickle.loads(DATA)
-                # print("Received data from %s:%d: %s" %
-                #       (addr[0], addr[1], decoded_message))
                 if type(decoded_message) == Transaction:
                     # Add transaction to the pool
                     self.add_transaction(decoded_message)
@@ -202,22 +200,19 @@ class Validator(Node):
                     # Probably need to add a leader flag here
                     if (end_time - start_time) >= 10:
                         start_time = int(time.time())
-                        last = None
                         print("Call Round Robin to chose the leader")
                         self.create_block(self.first, self.last)
                     elif len(self.mempool) >= 3:
                         start_time = int(time.time())
-                        last = None
                         blk = self.create_block(0, 3)
                         self.broadcast(blk)
                         self.mempool = list()
                 elif type(decoded_message) == Block:
-                    #print("Call verification/consensus function to vote on Block")
                     # If we are receiving an old block, we know we have received a client connection
                     if decoded_message.id <= self.blockchain.last_block.id:
                         h_name = socket.gethostbyaddr(addr[0])[0]
-                        c = client.Client(hostname=h_name, addr=addr[0], port=4848, bind=False)
-                        #self.client_connections.append((addr[0], 4848))
+                        c = client.Client(
+                            hostname=h_name, addr=addr[0], port=4848, bind=False)
                         self.connections.append(c)
                         # Send the chain from the id onwards
                         for blk in self.blockchain.chain[decoded_message.id:]:
@@ -242,7 +237,6 @@ class Validator(Node):
                 tx.status = "Open"
                 self.mempool.append(tx)
 
-
     def create_block(self, first, last):
         block_tx_pool = []
         for tx in range(first, last):
@@ -260,34 +254,12 @@ class Validator(Node):
         )
         return self.block
 
-
-    # Add block to the blockchain
     def add_block(self):
+        '''
+            Add block to the blockchain
+        '''
         self.first = self.last + 1
         self.blockchain.add_block(self.block, self.block.compute_hash())
-    
-
-    def send_certificate(self, addr, port):
-        '''
-            Sends the certificate to addr:port through 
-            standard, unencrypted TCP
-
-            :param str addr: the ipv4 address to send to
-            :param int port: the port number to send to
-        '''
-        certfile = open(self.certfile, 'rb').read()
-        print("Read certfile. Attempting to send to %s:%d" % (addr, port))
-        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-            try:
-                s.connect((addr, port))
-                # Alert receiver that you want to send a certificate
-                s.send(b'/cert')
-                s.sendall(certfile)  # Send the certificate
-            except OSError as e:
-                print(e)
-            except socket.timeout as e:
-                print(e)
-
 
     def verify_txs(self, block):
         '''
@@ -296,7 +268,6 @@ class Validator(Node):
             param: Block block: the new generated block sent from block generator
         '''
         for tx in block.transactions:
-            #tx = str(tx)
             if tx not in self.mempool:
                 return False
         return True
@@ -305,9 +276,9 @@ class Validator(Node):
 if __name__ == "__main__":
     port = int(input("Enter a port number: "))
     val = Validator(hostname="localhost", port=port)
-    
+
     # THIS COMMAND SHOULD ONLY BE EXECUTED ON THE VERY FIRST VALIDATOR TO GO ACTIVE
-    val.blockchain.create_genesis_block()
+    # val.blockchain.create_genesis_block()
     # marshal = Validator(hostname="home.marshalh.com", port=8080, bind=False)
 
     try:


### PR DESCRIPTION
The CA functionality (loading CA and creating the receiving context) originally thought to only be required in `Validator` is actually going to be needed in `Client` as well, so I am moving the related functions/variables to `Node`. 